### PR TITLE
more troubleshooting for ci error

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [ "master" ]
 
+permissions:
+  contents: write
+  
 jobs:
   build:
 


### PR DESCRIPTION
- getting release-action error "Error: Error 403: Resource not accessible by integration"
- found this issue https://github.com/ncipollo/release-action/issues/208 that says to add write permission? Trying.