### PR TITLE
add explicit version string to artifact path (because POM)

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -37,6 +37,6 @@ jobs:
     - name: Create Release  
       uses: ncipollo/release-action@v1.14.0
       with:
-        artifacts: "target/refine-groovy.zip"
+        artifacts: "target/refine-groovy-1.3.0.zip"
         prerelease: true
         tag: 1.3


### PR DESCRIPTION
- so evidentially, Maven assembly plugin likes to default to assembling with the version from the base POM, so we should probably just update the expected artifact path when creating a release to keep things simple?